### PR TITLE
Use dynamic default branch name instead of master

### DIFF
--- a/FEATURE.md
+++ b/FEATURE.md
@@ -4,7 +4,7 @@
 
 ### Usage
 
-This utility is built around the standard branch `master` and branches for releases that follow the format of MAJOR.MINOR.PATCH.
+This utility is built around the default branch and branches for releases that follow the format of MAJOR.MINOR.PATCH.
 
 Feature branches have specific format: USER-BASE-FEATURE.
 
@@ -17,7 +17,7 @@ Feature branches have specific format: USER-BASE-FEATURE.
 To start a new feature, go to the standard branch or a release branch.
 
 ```
-git checkout master
+git checkout <your-default-branch-name>
 ```
 
 Use the `start` subcommand with a feature name.
@@ -26,7 +26,7 @@ Use the `start` subcommand with a feature name.
 feature start my new feature
 ```
 
-For example, a new branch will be created called `rkiel-master-my-new-feature`
+For example, a new branch will be created called `rkiel-main-my-new-feature`
 
 #### Commit
 
@@ -69,7 +69,7 @@ This backup should not be used to collaborate with others.  It is just a persona
 feature rebase
 ```
 
-For example, `rkiel-master-my-new-feature` will be pushed out to `origin`.
+For example, `rkiel-default-my-new-feature` will be pushed out to `origin`.
 
 #### Merge
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ release help
 release join version
 release leave
 release list
-release start (major|minor|patch) from version [using master]
+release start (major|minor|patch) from version [using main]
 release tab [pattern]
 release trash local-branch-confirmation
 ```
@@ -30,10 +30,10 @@ Create an official release tag.
 release create version
 ```
 
-You must be on the `master` branch.  The latest code will be pulled from `master` and a tag created for the last commit.  For example, the following command will create a `v1.0.0` tag.
+You must be on the default branch.  The latest code will be pulled from the default branch and a tag created for the last commit.  For example, the following command will create a `v1.0.0` tag.
 
 ```bash
-git checkout master
+git checkout <your-default-branch-name>
 release create 1.0.0
 ```
 
@@ -42,20 +42,20 @@ release create 1.0.0
 Create a shared, release candidate branch.
 
 ```bash
-release start (major|minor|patch) from version [using master]
+release start (major|minor|patch) from version [using your-default-branch-name]
 ```
 
-The `version` specified must be an existing official release version.  The `major`, `minor`, and `patch` options will increment the new version number accordingly.  For example, to create a patch update, the following command will create a `rc1.0.1` release candidate branch.  If the optional `using master` is not specified, the release candiate branch will be created from the version tag (e.g. `v1.0.0`).  Otherwise, the release candiate branch will be created from `master`.  Also, if the repository contains a `package.json` file, the `version` property will automatically be set and committed.
+The `version` specified must be an existing official release version.  The `major`, `minor`, and `patch` options will increment the new version number accordingly.  For example, to create a patch update, the following command will create a `rc1.0.1` release candidate branch.  If the optional `using <your-default-branch-name>` is not specified, the release candiate branch will be created from the version tag (e.g. `v1.0.0`).  Otherwise, the release candiate branch will be created from the default branch.  Also, if the repository contains a `package.json` file, the `version` property will automatically be set and committed.
 
 ```bash
-git checkout master
+git checkout <your-default-branch-name>
 release start patch from 1.0.0
 ```
 or
 
 ```bash
-git checkout master
-release start patch from 1.0.0 from master
+git checkout <your-default-branch-name>
+release start patch from 1.0.0 from 
 ```
 
 Once the shared release candidate branch has been created, use `feature` to create and manage personal feature branches.
@@ -71,7 +71,7 @@ release join version
 The `version` specified must be an existing release candidate branch version.  A local tracking branch will be created.  For example, the following command will create `rc1.0.1` as a local tracking branch.
 
 ```bash
-git checkout master
+git checkout <your-default-branch-name>
 release join 1.0.1
 ```
 

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -24,11 +24,16 @@ alias show='git show -w'
 alias stash="git stash save"
 alias x='xgrep'
 
-
 alias sfind='find . -not \( -type d -name .git -prune \) -not \( -type d -name node_modes -prune \) -and \( -type f \)|sort -f'
 alias sgrep='find . -not \( -type d -name .git -prune \) -not \( -type d -name node_modes -prune \) -and \( -type f \)|sort -f|xargs grep --color=always'
 alias cgrep='grep --color=always'
 alias vgrep='grep -v'
+
+function default() 
+{
+  default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+  git checkout $default_branch
+}
 
 function get_feature_commands()
 {

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -38,11 +38,16 @@ alias show='git show -w'
 alias stash="git stash save"
 alias x='xgrep'
 
-
 alias sfind='find . -not \( -type d -name .git -prune \) -not \( -type d -name node_modes -prune \) -and \( -type f \)|sort -f'
 alias sgrep='find . -not \( -type d -name .git -prune \) -not \( -type d -name node_modes -prune \) -and \( -type f \)|sort -f|xargs grep --color=always'
 alias cgrep='grep --color=always'
 alias vgrep='grep -v'
+
+function default() 
+{
+  default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+  git checkout $default_branch
+}
 
 function get_feature_commands()
 {

--- a/lib/release/base.rb
+++ b/lib/release/base.rb
@@ -55,11 +55,6 @@ module Release
         error "Invalid release branch: #{current_branch}" unless current_branch =~ release_branch_pattern
       end
 
-      # TODO: Remove
-      # def validate_current_branch_master
-      #   error "Invalid starting branch: #{current_branch}.  Try switching to #{standard_branches.join(' ')}."  unless standard_branches.include? current_branch
-      # end
-
       def validate_current_branch_default
         error "Invalid starting branch: #{current_branch}. Try switching to #{standard_branches.join(' ')}." unless standard_branches.include?(current_branch)
       end
@@ -67,11 +62,6 @@ module Release
       def validate_release_branch_does_not_exist (branch)
         error "Version branch already exists: #{branch}" if remote_branch(branch) != ""
       end
-
-      # TODO: Remove
-      # def validate_branch_is_master (branch)
-      #   error "Branch must be master: #{branch}" if branch != "master"
-      # end
       
       def validate_branch_is_default (branch)
         error "Branch must be #{default_branch}: #{branch}" if branch != default_branch

--- a/lib/release/base.rb
+++ b/lib/release/base.rb
@@ -55,16 +55,26 @@ module Release
         error "Invalid release branch: #{current_branch}" unless current_branch =~ release_branch_pattern
       end
 
-      def validate_current_branch_master
-        error "Invalid starting branch: #{current_branch}.  Try switching to #{standard_branches.join(' ')}."  unless standard_branches.include? current_branch
+      # TODO: Remove
+      # def validate_current_branch_master
+      #   error "Invalid starting branch: #{current_branch}.  Try switching to #{standard_branches.join(' ')}."  unless standard_branches.include? current_branch
+      # end
+
+      def validate_current_branch_default
+        error "Invalid starting branch: #{current_branch}. Try switching to #{standard_branches.join(' ')}." unless standard_branches.include?(current_branch)
       end
 
       def validate_release_branch_does_not_exist (branch)
         error "Version branch already exists: #{branch}" if remote_branch(branch) != ""
       end
 
-      def validate_branch_is_master (branch)
-        error "Branch must be master: #{branch}" if branch != "master"
+      # TODO: Remove
+      # def validate_branch_is_master (branch)
+      #   error "Branch must be master: #{branch}" if branch != "master"
+      # end
+      
+      def validate_branch_is_default (branch)
+        error "Branch must be #{default_branch}: #{branch}" if branch != default_branch
       end
 
   end

--- a/lib/release/create.rb
+++ b/lib/release/create.rb
@@ -16,7 +16,7 @@ module Release
 
       validate_version_format version
 
-      validate_current_branch_master
+      validate_current_branch_default
       git_fetch_and_merge current_branch
 
       validate_version_is_new version

--- a/lib/release/finish.rb
+++ b/lib/release/finish.rb
@@ -23,8 +23,8 @@ module Release
       git_push release_branch
       git_push_tags
 
-      git_checkout :master
-      git_fetch_and_merge :master
+      git_checkout default_branch
+      git_fetch_and_merge default_branch
 
       git_local_branch_delete release_branch
 

--- a/lib/release/join.rb
+++ b/lib/release/join.rb
@@ -14,7 +14,7 @@ module Release
     def execute
       subcommand, version = *argv
 
-      validate_current_branch_master
+      validate_current_branch_default
       git_fetch_and_merge current_branch
 
       git_checkout_track release_branch_from_version(version)

--- a/lib/release/leave.rb
+++ b/lib/release/leave.rb
@@ -24,8 +24,8 @@ module Release
       error "Confirmation branch does not match current branch: #{confirmation_branch} vs #{release_branch}" if release_branch != confirmation_branch
       validate_current_branch_is_release
 
-      git_checkout :master
-      git_fetch_and_merge :master
+      git_checkout default_branch
+      git_fetch_and_merge default_branch
 
       git_local_branch_trash release_branch
     end

--- a/lib/release/list.rb
+++ b/lib/release/list.rb
@@ -12,7 +12,7 @@ module Release
     end
 
     def execute
-      validate_current_branch_master
+      validate_current_branch_default
       git_fetch_and_merge current_branch
 
       puts

--- a/lib/release/start.rb
+++ b/lib/release/start.rb
@@ -18,12 +18,12 @@ module Release
         starting_branch = nil
       when 6
         subcommand, level, verb, version, verb2, starting_branch = *argv
-        validate_branch_is_master(starting_branch)
+        validate_branch_is_default(starting_branch)
       end
 
       validate_version_format version
 
-      validate_current_branch_master
+      validate_current_branch_default
       git_fetch_and_merge current_branch
 
       validate_version_exists version

--- a/lib/release/start.rb
+++ b/lib/release/start.rb
@@ -8,7 +8,7 @@ module Release
     end
 
     def help
-      "release start (major|minor|patch) from version [using master]"
+      "release start (major|minor|patch) from version [using #{default_branch}]"
     end
 
     def execute

--- a/lib/release/trash.rb
+++ b/lib/release/trash.rb
@@ -24,8 +24,8 @@ module Release
       error "Confirmation branch does not match current branch: #{confirmation_branch} vs #{release_branch}" if release_branch != confirmation_branch
       validate_current_branch_is_release
 
-      git_checkout :master
-      git_fetch_and_merge :master
+      git_checkout default_branch
+      git_fetch_and_merge default_branch
 
       git_local_branch_trash release_branch
 

--- a/lib/shared/branchability.rb
+++ b/lib/shared/branchability.rb
@@ -9,8 +9,12 @@ module Shared
       @remote_branch  ||= `git branch -r|grep origin|grep -v 'HEAD'|grep #{branch}`.strip
     end
 
+    def default_branch
+      @default_branch ||= `git remote show origin | grep 'HEAD branch' | cut -d' ' -f5`.strip
+    end
+
     def standard_branches
-      ['master','release']
+      [default_branch, 'release']
     end
 
     def version_pattern


### PR DESCRIPTION
This PR updates the feature utility to use a dynamic default branch name instead of using master. 

Caveats: 
- A few changes here might be a little bit hacky. I think this is pretty sound, though. 
- I was not sure exactly how to update the new JS code to work this way, so I avoided that for now. 
- Please let me know if I should update the documentation further. I changed the word `master` used throughout the docs to some combination of `<your-default-branch-name>` or `main` or `default` for different examples. 